### PR TITLE
Add mactex

### DIFF
--- a/configuration/nix/flake.nix
+++ b/configuration/nix/flake.nix
@@ -87,6 +87,7 @@
           "notion"
           "stats"
           "font-meslo-lg-nerd-font"
+          "mactext"
         ];        # GUI apps from Homebrew Casks
         masApps = {
         };

--- a/configuration/nix/flake.nix
+++ b/configuration/nix/flake.nix
@@ -87,7 +87,7 @@
           "notion"
           "stats"
           "font-meslo-lg-nerd-font"
-          "mactext"
+          "mactex"
         ];        # GUI apps from Homebrew Casks
         masApps = {
         };

--- a/configuration/nix/flake.nix
+++ b/configuration/nix/flake.nix
@@ -80,6 +80,7 @@
           "pre-commit"
           "zsh-autosuggestions"
           "zsh-syntax-highlighting"
+          "texlive"
         ];        # CLI tools from Homebrew
         casks = [ 
           "raycast"


### PR DESCRIPTION
# What does this PR do?

- Add `texlive` and `mactex`

This is useful because it allows me to use the `Latex workshop` extension in VSCode/Cursor, enabling LaTeX build instead, which is incredible as it makes PRs for papers easier