### PR TITLE
refactor: removed uv from from flake.nix and moved it to setup.sh - a…

### DIFF
--- a/configuration/nix/flake.nix
+++ b/configuration/nix/flake.nix
@@ -56,7 +56,6 @@
           pkgs.tmux
           pkgs.code-cursor
           pkgs.arc-browser
-          pkgs.uv # Astral UV python package manager
           pkgs.poetry # Poetry python package manager
           pkgs.kitty
           pkgs.ffmpeg
@@ -70,25 +69,25 @@
        homebrew = {
         enable = true;
         brews = [ 
-          "mas"
-          "git"
-          "swift-format"
-          "whisperkit-cli"
-          "powerlevel10k"
-          "tree"
-          "huggingface-cli"
-          "pre-commit"
-          "zsh-autosuggestions"
-          "zsh-syntax-highlighting"
-          "texlive"
+          "mas" # Mac App Store CLI
+          "git" # Git CLI
+          "swift-format" # Swift format for Swift code
+          "whisperkit-cli" # Argmax WhisperKit CLI
+          "powerlevel10k" # Powerlevel10k zsh theme
+          "tree" # Tree command for directory listing
+          "huggingface-cli" # Hugging Face CLI
+          "pre-commit" # Pre-commit hooks for git
+          "zsh-autosuggestions" # Autosuggestions for zsh
+          "zsh-syntax-highlighting" # Syntax highlighting for zsh
+          "texlive" # TeX Live for LaTeX -> necessary for VSCode/Cursor to render LaTeX
         ];        # CLI tools from Homebrew
         casks = [ 
-          "raycast"
-          "karabiner-elements"
-          "notion"
-          "stats"
-          "font-meslo-lg-nerd-font"
-          "mactex"
+          "raycast" # Raycast -> better Spotlight
+          "karabiner-elements" # Karabiner -> Keyboard remapping
+          "notion" # Notion -> Note-taking
+          "stats" # Stats -> System monitor
+          "font-meslo-lg-nerd-font" # Meslo Nerd Font -> Better font for terminal
+          "mactex" # MacTeX -> LaTeX for macOS
         ];        # GUI apps from Homebrew Casks
         masApps = {
         };

--- a/configuration/zsh/.zshrc
+++ b/configuration/zsh/.zshrc
@@ -42,6 +42,7 @@ alias timer-cli='uvx --from timer-cli timer'
 alias dotfiles='cd ~/dotfiles'
 alias dotfiles-open='cursor ~/dotfiles'
 alias zshrc-open='cursor ~/.zshrc'
+alias nix-sync='sudo darwin-rebuild switch --flake ~/.config/nix'
 alias source-zsh='source ~/.zshrc'
 
 ################### SSH AGENT CONFIGURATION ###################

--- a/utilities/setup.sh
+++ b/utilities/setup.sh
@@ -31,6 +31,7 @@ echo -e "${MAGENTA}║                   Complete Machine Setup Automation      
 echo -e "${MAGENTA}╚══════════════════════════════════════════════════════════════════════╝${NC}"
 echo ""
 echo "Repository root: $REPO_ROOT"
+echo "Script directory: $SCRIPT_DIR"
 echo "This script will set up your entire working environment."
 echo ""
 
@@ -140,6 +141,16 @@ if [ ! -d "$HOME/.tmux/plugins/tpm" ]; then
                 "git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm"
 else
     echo -e "${GREEN}✓ tmux plugin manager (tpm) already installed${NC}"
+    echo ""
+fi
+
+# Install uv (Python package manager)
+# Using official installer instead of brew/nixpkgs to get the latest version
+if ! command_exists uv; then
+    run_command "Installing uv (Python package manager)" \
+                "curl -LsSf https://astral.sh/uv/install.sh | sh"
+else
+    echo -e "${GREEN}✓ uv (Python package manager) already installed${NC}"
     echo ""
 fi
 


### PR DESCRIPTION
# What does this PR do?

I removed the `uv` installation from `flake.nix` or `brew` because it uses older versions. I moved the `uv` installation to a `manual` installation in the setup.sh` script. Also added a new alias called `nix-sync` that is used to rebuild `nix-darwin` with `sudo darwin-rebuild switch --flake ~/.config/nix`