### PR TITLE
[v11] Add gcloud CLI cask, Jira CLI, and Obsidian cask note

### DIFF
--- a/configuration/nix/flake.nix
+++ b/configuration/nix/flake.nix
@@ -85,6 +85,7 @@
           "node" # Node.js for JavaScript and TypeScript
           "rustup" # Rustup for Rust programming language
           "anemll-profile" # ANE MLL profiling tool
+          "jira-cli" # Jira CLI
         ];        # CLI tools from Homebrew
         casks = [ 
           "raycast" # Raycast -> better Spotlight
@@ -93,7 +94,8 @@
           "stats" # Stats -> System monitor
           "font-meslo-lg-nerd-font" # Meslo Nerd Font -> Better font for terminal
           "mactex" # MacTeX -> LaTeX for macOS
-          "obsidian"
+          "obsidian" # Obsidian Desktop -> Note-taking
+          "gcloud-cli" # Google Cloud CLI
         ];        # GUI apps from Homebrew Casks
         masApps = {
         };


### PR DESCRIPTION
## Summary
- **gcloud-cli** (cask): install Google Cloud SDK from Homebrew casks.
- **jira-cli** (formula): add Atlassian Jira CLI to the Homebrew formula list.
- **Obsidian**: add an inline comment for the existing cask entry (no install change).

## Test plan
- [x] Rebuild or apply your usual Nix/Darwin + Homebrew flow; confirm the new packages are recognized and any existing Obsidian install is unchanged.

Made with [Cursor](https://cursor.com)